### PR TITLE
Security: unpin passport-oauth2 (CVE-2021-41580)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "csv-stringify": "^1.0.0",
     "jsonwebtoken": "8.2.0",
-    "passport-oauth2": "1.4.0",
+    "passport-oauth2": "^1.6.1",
     "safe-buffer": "^5.1.2",
     "superagent": "3.8.2"
   },


### PR DESCRIPTION
I believe this vulnerability does not directly affect Docusign customers, as the OAuth2 ID Provider won't allow an empty token.

However, unpinning this dependency will keep automated audit tools happy, plus allows people to more easily take advantage of fixes for future vulnerabilities.

https://github.com/advisories/GHSA-f794-r6xc-hf3v