### PR TITLE
encode state in authorization uri

### DIFF
--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -732,7 +732,7 @@
       "&scope=" + formattedScopes +
       "&client_id="+ clientId +
       "&redirect_uri=" + encodeURIComponent(redirectUri) +
-      (state ? "&state=" + state : '');
+      (state ? "&state=" + encodeURIComponent(state) : '');
   };
 
   /**


### PR DESCRIPTION
e.g. when using an base64 encoded string.

Like the `redirectUri`, the `state` is an user input and as such not safe to be used in an url without escaping certain characters