### PR TITLE
Bugfix: Fix `getAttachment` return type

### DIFF
--- a/src/api/EnvelopesApi.js
+++ b/src/api/EnvelopesApi.js
@@ -3825,7 +3825,7 @@ If the envelope is `In Process`, meaning that it has been sent and has not  been
       var authNames = ['docusignAccessCode'];
       var contentTypes = [];
       var accepts = ['application/json'];
-      var returnType = null;
+      var returnType = Object;
 
       return this.apiClient.callApi(
         '/v2.1/accounts/{accountId}/envelopes/{envelopeId}/attachments/{attachmentId}', 'GET',


### PR DESCRIPTION
ℹ️   This PR refers to #315 ℹ️ 

-----------------------------------

### Changes:

- Fix `getAttachment()` method from `EnvelopesApi` by changing its return type

