### PR TITLE
Version 6.0.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,10 @@ notifications:
     on_failure: change
 
 node_js:
-  - "6"
-  - "7"
-  - "8"
-  - "9"
-  - "10"
-  - "11"
   - "12"
   - "13"
+  - "14"
+  - "16"
 
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for Product Release Notes.
 
 
+## [v6.0.0] - eSignature API v2.1-22.3.01.00 - 2023-01-23
+### Breaking 
+  - Deprecating Node versions <12
+### Security
+  - Update jsonwebtoken package to 9.0.0 addressing CVE-2022-23529
 ## [v5.20.0] - eSignature API v2.1-22.3.01.00 - 2022-11-22
 ### Changed
 - Added support for version v2.1-22.3.01.00 of the DocuSign ESignature API.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This client has the following external dependencies:
 
 **Optional:**
 *   Async v2.6.2
-*   Jsonwebtoken v8.2.0
+*   Jsonwebtoken v9.0.0
 *   Passport-oauth2
 *   Path
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusign-esign",
-  "version": "5.20.0",
+  "version": "6.0.0",
   "description": "DocuSign Node.js API client.",
   "license": "MIT",
   "main": "src/index.js",
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "csv-stringify": "^1.0.0",
-    "jsonwebtoken": "8.2.0",
+    "jsonwebtoken": "^9.0.0",
     "passport-oauth2": "^1.6.1",
     "safe-buffer": "^5.1.2",
     "superagent": "3.8.2"


### PR DESCRIPTION
### Breaking 
  - Deprecating Node versions <12
### Security
  - Update jsonwebtoken package to 9.0.0 addressing CVE-2022-23529