### PR TITLE
Fix generateAccessToken method

### DIFF
--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -906,7 +906,7 @@
       OAuthToken = require("./OAuth").OAuthToken;
 
     const requestConfig = {
-      baseURL: `https://${oAuthBasePath}`,
+      baseURL: `https://${this.oAuthBasePath}`,
       method: "post",
       url: "/oauth/token",
       headers: {


### PR DESCRIPTION
Fix `generateAccessToken` method, failing Authorization Code Grant flow due this.

Just tested and it's working.

This issue was introduced in the most recent RC version of the lib
https://github.com/docusign/docusign-esign-node-client/issues/342#issuecomment-2127952824