### PR TITLE
Version 8.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,80 @@
 See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for Product Release Notes.
 
 
+## [v8.0.0] - eSignature API v2.1-24.2.00.00 - 2024-07-25
+### Breaking Changes
+
+<details>
+<summary>API Changes (Click to expand)</summary>
+
+<div style="margin-left: 20px;">
+
+<br/>
+Added support for version v2.1-24.2.00.00 of the Docusign ESignature API.
+
+  ## Endpoint-Specific Changes
+
+  ### Updated [Envelopes: get](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/get/)
+  Added new optional query parameter named `include_anchor_tab_locations` of type string.
+
+  ### Updated [Envelopes: update](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/update/)
+  Added new optional query parameter named `recycle_on_void` of type string.
+
+  ### Updated [EnvelopeViews : createCorrect](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopeviews/createcorrect/)
+  Request body object `correctViewRequest` has been changed to `envelopeViewRequest`.
+
+  ## Model Changes
+
+  ### Updated existing models
+
+  ### `accountInformation`
+
+  - **Added fields:**
+    - `freeEnvelopeSendsRemainingForAdvancedDocGen`
+
+  ### `accountSettingsInformation`
+
+  - **Added fields:**
+    - `defaultSigningResponsiveView`
+    - `defaultSigningResponsiveViewMetadata`
+    - `dss_SCOREFDN_196_Rebrand_DocuSignIsNotAVerb`
+    - `enableAdditionalAdvancedWebFormsFeatures`
+    - `enableAdditionalAdvancedWebFormsFeaturesMetadata`
+
+- **Removed fields:**
+    - `enableSaveAsEnvelopeCustomFieldInWebForms`
+    - `enableSaveAsEnvelopeCustomFieldInWebFormsMetadata`
+
+### `bulksendingCopyDocGenFormField`
+
+- **Added field:**
+  - `rowValues`
+
+### `notaryRecipient`
+
+- **Added field:**
+  - `canNotaryCorrectEnvelope`
+
+### `tabAccountSettings`
+
+- **Added field:**
+  - `enableTabAgreementDetails`
+  - `enableTabAgreementDetailsMetadata`
+
+
+### Newly added Models
+
+- `bulkSendingCopyDocGenFormFieldRowValue`
+
+</div>
+</details>
+
+
+### Other Changes
+- Converted `defaultHeaders` from a shared global state to a local state within each `ApiClient` instance.
+- Fixed the overriding of the Authorization header in `GetUserInfo` when `defaultHeaders` already had an Authorization header.
+- Updated the SDK release version.
+
 ## [v8.0.0-rc2] - eSignature API v2.1-24.2.00.00 - 2024-07-19
 ### Changed
 - Converted `defaultHeaders` from a shared global state to a local state within each `ApiClient` instance.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This client SDK is provided as open source, which enables you to customize its f
 <a id="versionInformation"></a>
 ### Version Information
 - **API version**: v2.1
-- **Latest SDK version**: 8.0.0-rc2
+- **Latest SDK version**: 8.0.0
 
 <a id="requirements"></a>
 ## Requirements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusign-esign",
-  "version": "8.0.0-rc2",
+  "version": "8.0.0",
   "description": "Docusign Node.js API client.",
   "license": "MIT",
   "main": "src/index.js",

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -185,7 +185,7 @@
     this.defaultHeaders = {
       "X-DocuSign-SDK": "Node",
       "Node-Ver": process.version,
-      "User-Agent": `Swagger-Codegen/v2.1/8.0.0-rc2/node/${process.version}`,
+      "User-Agent": `Swagger-Codegen/v2.1/8.0.0/node/${process.version}`,
     };  
 
     opts = {...defaults, ...opts};


### PR DESCRIPTION
### Breaking Changes

<details>
<summary>API Changes (Click to expand)</summary>

<div style="margin-left: 20px;">

<br/>
Added support for version v2.1-24.2.00.00 of the Docusign ESignature API.

  ## Endpoint-Specific Changes

  ### Updated [Envelopes: get](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/get/)
  Added new optional query parameter named `include_anchor_tab_locations` of type string.

  ### Updated [Envelopes: update](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/update/)
  Added new optional query parameter named `recycle_on_void` of type string.

  ### Updated [EnvelopeViews : createCorrect](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopeviews/createcorrect/)
  Request body object `correctViewRequest` has been changed to `envelopeViewRequest`.

  ## Model Changes

  ### Updated existing models

  ### `accountInformation`

  - **Added fields:**
    - `freeEnvelopeSendsRemainingForAdvancedDocGen`

  ### `accountSettingsInformation`

  - **Added fields:**
    - `defaultSigningResponsiveView`
    - `defaultSigningResponsiveViewMetadata`
    - `dss_SCOREFDN_196_Rebrand_DocuSignIsNotAVerb`
    - `enableAdditionalAdvancedWebFormsFeatures`
    - `enableAdditionalAdvancedWebFormsFeaturesMetadata`

- **Removed fields:**
    - `enableSaveAsEnvelopeCustomFieldInWebForms`
    - `enableSaveAsEnvelopeCustomFieldInWebFormsMetadata`

### `bulksendingCopyDocGenFormField`

- **Added field:**
  - `rowValues`

### `notaryRecipient`

- **Added field:**
  - `canNotaryCorrectEnvelope`

### `tabAccountSettings`

- **Added field:**
  - `enableTabAgreementDetails`
  - `enableTabAgreementDetailsMetadata`


### Newly added Models

- `bulkSendingCopyDocGenFormFieldRowValue`

</div>
</details>


### Other Changes
- Converted `defaultHeaders` from a shared global state to a local state within each `ApiClient` instance.
- Fixed the overriding of the Authorization header in `GetUserInfo` when `defaultHeaders` already had an Authorization header.
- Updated the SDK release version.
